### PR TITLE
added a brace-pop utility context

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -306,9 +306,7 @@ contexts:
         3: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.include.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
 
   sections:
     - match: |-
@@ -337,9 +335,7 @@ contexts:
       push:
         - meta_scope: meta.section.latex
         - meta_content_scope: entity.name.section.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: main
 
   structure:
@@ -448,9 +444,7 @@ contexts:
       scope: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.group.brace.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: math-content
 
   math-content:
@@ -472,9 +466,7 @@ contexts:
       push:
         - meta_scope: meta.function.ensuremath.latex
         - meta_content_scope: meta.environment.math.inline.ensuremath.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: math-content
 
     - match: (\\\()
@@ -568,9 +560,7 @@ contexts:
       push:
         - meta_scope: meta.function.emph.latex
         - meta_content_scope: markup.italic.emph.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: main
     - match: ((\\)textit)(\{)
       captures:
@@ -580,9 +570,7 @@ contexts:
       push:
         - meta_scope: meta.function.textit.latex
         - meta_content_scope: markup.italic.textit.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: main
     - match: ((\\)textbf)(\{)
       captures:
@@ -592,9 +580,7 @@ contexts:
       push:
         - meta_scope: meta.function.textbf.latex
         - meta_content_scope: markup.bold.textbf.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: main
     - match: ((\\)texttt)(\{)
       captures:
@@ -604,9 +590,7 @@ contexts:
       push:
         - meta_scope: meta.function.texttt.latex
         - meta_content_scope: markup.raw.texttt.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: main
     - match: ((\\)textsl)(\{)
       captures:
@@ -616,9 +600,7 @@ contexts:
       push:
         - meta_scope: meta.function.textsl.latex
         - meta_content_scope: markup.italic.textsl.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: main
     - match: ((\\)text)(\{)
       captures:
@@ -626,9 +608,7 @@ contexts:
         2: punctuation.definition.backslash.latex
         3: punctuation.definition.group.brace.begin.latex
       push:
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: main
     - match: ((\\)underline)(\{)
       captures:
@@ -638,9 +618,7 @@ contexts:
       push:
         - meta_scope: meta.function.underline.latex
         - meta_content_scope: markup.underline.underline.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: main
 
   footnote:
@@ -656,9 +634,7 @@ contexts:
           set:
             - meta_scope: meta.function.footnote.latex meta.group.brace.latex
             - meta_content_scope: markup.italic.footnote.latex
-            - match: \}
-              scope: punctuation.definition.group.brace.end.latex
-              pop: true
+            - include: brace-pop
             - include: main
         - match: (?=\S)
           pop: true
@@ -710,9 +686,7 @@ contexts:
             - meta_scope: meta.group.brace.latex
             - match: '[a-zA-Z0-9\.:/*!^_-]+'
               scope: constant.other.citation.latex
-            - match: \}
-              scope: punctuation.definition.group.brace.end.latex
-              pop: true
+            - include: brace-pop
         - match: ''
           pop: true
     - match: |-
@@ -734,9 +708,7 @@ contexts:
             - meta_scope: meta.function.reference.latex meta.group.brace.latex
             - match: '[a-zA-Z0-9\.:/*!^_-]+'
               scope: constant.other.reference.latex
-            - match: \}
-              scope: punctuation.definition.group.brace.end.latex
-              pop: true
+            - include: brace-pop
         - match: ''
           pop: true
     - match: ((\\)label)(\{)
@@ -748,9 +720,7 @@ contexts:
         - meta_scope: meta.function.label.latex
         - match: '[a-zA-Z0-9\.:/*!^_-]+'
           scope: entity.name.label.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
 
   begin-end-commands:
     - match: ((\\)begin)(\{)\s*(\w*)\*?\s*(\})
@@ -1577,9 +1547,7 @@ contexts:
       push:
         - meta_include_prototype: false
         - meta_scope: meta.function.newcolumntype.latex
-        - match: '\}'
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: array-preamble
 
 
@@ -1623,9 +1591,7 @@ contexts:
     - match: \{
       scope: punctuation.definition.group.brace.begin.latex
       push:
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: general-constants
         - include: general-commands
         - include: array-preamble
@@ -1645,9 +1611,7 @@ contexts:
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.before-column-decl.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: general-constants
         - include: general-commands
         - include: macro-braces
@@ -1658,9 +1622,7 @@ contexts:
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.after-column-decl.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: general-constants
         - include: general-commands
         - include: macro-braces
@@ -1674,9 +1636,7 @@ contexts:
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.inter-column-decl.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: general-constants
         - include: general-commands
         - include: macro-braces
@@ -1687,9 +1647,7 @@ contexts:
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.inter-column-decl.latex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.latex
-          pop: true
+        - include: brace-pop
         - include: general-constants
         - include: general-commands
         - include: macro-braces

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -306,7 +306,7 @@ contexts:
         3: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.include.latex
-        - include: brace-pop
+        - include: brace-group-end
 
   sections:
     - match: |-
@@ -335,7 +335,7 @@ contexts:
       push:
         - meta_scope: meta.section.latex
         - meta_content_scope: entity.name.section.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
 
   structure:
@@ -444,7 +444,7 @@ contexts:
       scope: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.group.brace.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: math-content
 
   math-content:
@@ -466,7 +466,7 @@ contexts:
       push:
         - meta_scope: meta.function.ensuremath.latex
         - meta_content_scope: meta.environment.math.inline.ensuremath.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: math-content
 
     - match: (\\\()
@@ -560,7 +560,7 @@ contexts:
       push:
         - meta_scope: meta.function.emph.latex
         - meta_content_scope: markup.italic.emph.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
     - match: ((\\)textit)(\{)
       captures:
@@ -570,7 +570,7 @@ contexts:
       push:
         - meta_scope: meta.function.textit.latex
         - meta_content_scope: markup.italic.textit.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
     - match: ((\\)textbf)(\{)
       captures:
@@ -580,7 +580,7 @@ contexts:
       push:
         - meta_scope: meta.function.textbf.latex
         - meta_content_scope: markup.bold.textbf.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
     - match: ((\\)texttt)(\{)
       captures:
@@ -590,7 +590,7 @@ contexts:
       push:
         - meta_scope: meta.function.texttt.latex
         - meta_content_scope: markup.raw.texttt.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
     - match: ((\\)textsl)(\{)
       captures:
@@ -600,7 +600,7 @@ contexts:
       push:
         - meta_scope: meta.function.textsl.latex
         - meta_content_scope: markup.italic.textsl.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
     - match: ((\\)text)(\{)
       captures:
@@ -608,7 +608,7 @@ contexts:
         2: punctuation.definition.backslash.latex
         3: punctuation.definition.group.brace.begin.latex
       push:
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
     - match: ((\\)underline)(\{)
       captures:
@@ -618,7 +618,7 @@ contexts:
       push:
         - meta_scope: meta.function.underline.latex
         - meta_content_scope: markup.underline.underline.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
 
   footnote:
@@ -634,7 +634,7 @@ contexts:
           set:
             - meta_scope: meta.function.footnote.latex meta.group.brace.latex
             - meta_content_scope: markup.italic.footnote.latex
-            - include: brace-pop
+            - include: brace-group-end
             - include: main
         - match: (?=\S)
           pop: true
@@ -686,7 +686,7 @@ contexts:
             - meta_scope: meta.group.brace.latex
             - match: '[a-zA-Z0-9\.:/*!^_-]+'
               scope: constant.other.citation.latex
-            - include: brace-pop
+            - include: brace-group-end
         - match: ''
           pop: true
     - match: |-
@@ -708,7 +708,7 @@ contexts:
             - meta_scope: meta.function.reference.latex meta.group.brace.latex
             - match: '[a-zA-Z0-9\.:/*!^_-]+'
               scope: constant.other.reference.latex
-            - include: brace-pop
+            - include: brace-group-end
         - match: ''
           pop: true
     - match: ((\\)label)(\{)
@@ -720,7 +720,7 @@ contexts:
         - meta_scope: meta.function.label.latex
         - match: '[a-zA-Z0-9\.:/*!^_-]+'
           scope: entity.name.label.latex
-        - include: brace-pop
+        - include: brace-group-end
 
   begin-end-commands:
     - match: ((\\)begin)(\{)\s*(\w*)\*?\s*(\})
@@ -1547,7 +1547,7 @@ contexts:
       push:
         - meta_include_prototype: false
         - meta_scope: meta.function.newcolumntype.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: array-preamble
 
 
@@ -1591,7 +1591,7 @@ contexts:
     - match: \{
       scope: punctuation.definition.group.brace.begin.latex
       push:
-        - include: brace-pop
+        - include: brace-group-end
         - include: general-constants
         - include: general-commands
         - include: array-preamble
@@ -1611,7 +1611,7 @@ contexts:
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.before-column-decl.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: general-constants
         - include: general-commands
         - include: macro-braces
@@ -1622,7 +1622,7 @@ contexts:
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.after-column-decl.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: general-constants
         - include: general-commands
         - include: macro-braces
@@ -1636,7 +1636,7 @@ contexts:
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.inter-column-decl.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: general-constants
         - include: general-commands
         - include: macro-braces
@@ -1647,7 +1647,7 @@ contexts:
         2: punctuation.definition.group.brace.begin.latex
       push:
         - meta_scope: meta.function.inter-column-decl.latex
-        - include: brace-pop
+        - include: brace-group-end
         - include: general-constants
         - include: general-commands
         - include: macro-braces

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -156,7 +156,7 @@ contexts:
       scope: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.group.brace.tex
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
 
   # within macros, it is possible that only part of some nested struture
@@ -167,7 +167,7 @@ contexts:
       scope: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.group.brace.tex
-        - include: brace-pop
+        - include: brace-group-end
         - include: general-constants
         - include: general-commands
         - include: macro-braces
@@ -180,7 +180,7 @@ contexts:
         3: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.function.box.tex
-        - include: brace-pop
+        - include: brace-group-end
         - include: main
 
   macros:
@@ -238,7 +238,7 @@ contexts:
 
   def-definition-body:
     - meta_scope: meta.function.body.tex meta.group.brace.tex
-    - include: brace-pop
+    - include: brace-group-end
     - include: general-constants
     - include: general-commands
     - include: macro-braces
@@ -324,7 +324,7 @@ contexts:
       scope: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.group.brace.tex
-        - include: brace-pop
+        - include: brace-group-end
         - include: math-content
 
   math-brackets:
@@ -383,8 +383,8 @@ contexts:
     - match: (?=\S)
       pop: true
 
-  # matches a closing brace pops the context
-  brace-pop:
+  # matches a closing brace and pops the context
+  brace-group-end:
     - match: \}
       scope: punctuation.definition.group.brace.end.tex
       pop: true

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -156,9 +156,7 @@ contexts:
       scope: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.group.brace.tex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.tex
-          pop: true
+        - include: brace-pop
         - include: main
 
   # within macros, it is possible that only part of some nested struture
@@ -169,9 +167,7 @@ contexts:
       scope: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.group.brace.tex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.tex
-          pop: true
+        - include: brace-pop
         - include: general-constants
         - include: general-commands
         - include: macro-braces
@@ -184,9 +180,7 @@ contexts:
         3: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.function.box.tex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.tex
-          pop: true
+        - include: brace-pop
         - include: main
 
   macros:
@@ -244,9 +238,7 @@ contexts:
 
   def-definition-body:
     - meta_scope: meta.function.body.tex meta.group.brace.tex
-    - match: \}
-      scope: punctuation.definition.group.brace.end.tex
-      pop: 1
+    - include: brace-pop
     - include: general-constants
     - include: general-commands
     - include: macro-braces
@@ -332,9 +324,7 @@ contexts:
       scope: punctuation.definition.group.brace.begin.tex
       push:
         - meta_scope: meta.group.brace.tex
-        - match: \}
-          scope: punctuation.definition.group.brace.end.tex
-          pop: true
+        - include: brace-pop
         - include: math-content
 
   math-brackets:
@@ -391,6 +381,12 @@ contexts:
   # matches any nospace and pops the context
   else-pop:
     - match: (?=\S)
+      pop: true
+
+  # matches a closing brace pops the context
+  brace-pop:
+    - match: \}
+      scope: punctuation.definition.group.brace.end.tex
       pop: true
 
   immediately-pop:


### PR DESCRIPTION
This PR adds a utility scope `brace-pop` that looks for the closing brace for any brace-group, which is a very common operation in TeX syntaxes. I've developed it against this branch, instead of the current master, because it really makes more sense to introduce this utility if it is shared between TeX and LaTeX.

At the moment, one of the tests fails, because it is looking for `punctuation.definition.group.brace.end.latex`, but the closing brace is now from the TeX syntax, so it gets `punctuation.definition.group.brace.end.tex`. How should such a situation be handled?