### PR TITLE
[Python] Handle docstring "summary" starting on second line

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2118,16 +2118,18 @@ contexts:
       captures:
         1: storage.type.string.python
         2: comment.block.documentation.python punctuation.definition.comment.begin.python
-      push:
-        - double-quoted-docstring-summery
-        - else-pop
+      push: maybe-double-quoted-docstring-summery
     - match: ^\s*(?i)(ur|ru?)(""")
       captures:
         1: storage.type.string.python
         2: comment.block.documentation.python punctuation.definition.comment.begin.python
-      push:
-        - double-quoted-docstring-summery
-        - else-pop
+      push: maybe-double-quoted-docstring-summery
+
+  maybe-double-quoted-docstring-summery:
+    - meta_content_scope: comment.block.documentation.python
+    - include: double-quoted-docstring-end
+    - match: (?=\S)
+      set: double-quoted-docstring-summery
 
   double-quoted-docstring-summery:
     - meta_content_scope: comment.block.documentation.summary.python

--- a/Python/syntax_test_python.py
+++ b/Python/syntax_test_python.py
@@ -25,6 +25,17 @@ ur"""Raw docstring \"""
 #                    ^^^ comment.block.documentation.python punctuation.definition.comment.end.python
 #                       ^ meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
 
+"""
+#^^^ comment.block.documentation.python
+docstring starting on the second line
+"""
+
+"""
+docstring starting on the second line
+# <- comment.block.documentation.summary.python
+#^^^ comment.block.documentation.summary.python
+"""
+
 debug = False
 """
 This is a variable docstring, as supported by sphinx and epydoc


### PR DESCRIPTION
The non-summary whitespace prior to the first non-whitespace character of the summary line should not receive the summary scope.